### PR TITLE
Update dependencies for compatibility with Java 11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,9 +37,9 @@ repositories {
 }
 
 dependencies {
-    api "commons-logging:commons-logging:1.1.1"
-    testImplementation "org.codehaus.groovy:groovy-all:2.4.1"
-    testImplementation "org.spockframework:spock-core:0.7-groovy-2.0"
+    api "commons-logging:commons-logging:1.2"
+    testImplementation "org.codehaus.groovy:groovy-all:2.5.13"
+    testImplementation "org.spockframework:spock-core:1.3-groovy-2.5"
 }
 
 


### PR DESCRIPTION
The build of hcl4j currently fails with Java 11 (and higher) because some of the (test) dependencies are not compatible with Java 11.

This PR updates the following dependencies:

* Commons Logging 1.2
* Groovy 2.5.13
* Spock 1.3 (for Groovy 2.5.x)

Java 8 (successful):
```
# ./gradlew --no-daemon --version

------------------------------------------------------------
Gradle 6.5
------------------------------------------------------------

Build time:   2020-06-02 20:46:21 UTC
Revision:     a27f41e4ae5e8a41ab9b19f8dd6d86d7b384dad4

Kotlin:       1.3.72
Groovy:       2.5.11
Ant:          Apache Ant(TM) version 1.10.7 compiled on September 1 2019
JVM:          1.8.0_265 (Azul Systems, Inc. 25.265-b11)
OS:           Mac OS X 10.15.7 x86_64

# ./gradlew --no-daemon --quiet check
Note: /.../hcl4j/src/main/java/com/bertramlabs/plugins/hcl4j/HCLParser.java uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
```

Java 11:
```
# ./gradlew --no-daemon --version

------------------------------------------------------------
Gradle 6.5
------------------------------------------------------------

Build time:   2020-06-02 20:46:21 UTC
Revision:     a27f41e4ae5e8a41ab9b19f8dd6d86d7b384dad4

Kotlin:       1.3.72
Groovy:       2.5.11
Ant:          Apache Ant(TM) version 1.10.7 compiled on September 1 2019
JVM:          11.0.8 (Azul Systems, Inc. 11.0.8+10-LTS)
OS:           Mac OS X 10.15.7 x86_64

# ./gradlew --no-daemon --quiet check
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.codehaus.groovy.reflection.CachedClass$3$1 (file:/.../.gradle/caches/modules-2/files-2.1/org.codehaus.groovy/groovy-all/2.4.1/a9ca9c9de09361ec2a18d2c058d2524fbd8eae0c/groovy-all-2.4.1.jar) to method java.lang.Object.finalize()
WARNING: Please consider reporting this to the maintainers of org.codehaus.groovy.reflection.CachedClass$3$1
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release

21 tests completed, 15 failed

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':test'.
> There were failing tests. See the report at: file:///.../Projects/hcl4j/build/reports/tests/test/index.html

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 4s
```

Java 11 with updated dependencies:
```
# ./gradlew --no-daemon --quiet check
Note: /.../hcl4j/src/main/java/com/bertramlabs/plugins/hcl4j/HCLParser.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: /.../hcl4j/src/main/java/com/bertramlabs/plugins/hcl4j/HCLParser.java uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.codehaus.groovy.reflection.CachedClass (file:/.../.gradle/caches/modules-2/files-2.1/org.codehaus.groovy/groovy/2.5.13/ac054525fdc81cbd0bc2552b57052ebb1a93cd40/groovy-2.5.13.jar) to method java.lang.Object.finalize()
WARNING: Please consider reporting this to the maintainers of org.codehaus.groovy.reflection.CachedClass
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
```


<details>
<summary>Specific exceptions during tests</summary>

```
com.bertramlabs.plugins.hcl4j.HCLLexerSpec > should generate symbols from hcl STANDARD_OUT
    [[Block, variables], [Block, service]]

com.bertramlabs.plugins.hcl4j.HCLParserSpec > should generate Map from hcl FAILED
    java.lang.ClassCastException: class [B cannot be cast to class [C ([B and [C are in module java.base of loader 'bootstrap')
        at groovy.json.internal.FastStringUtils$StringImplementation$1.toCharArray(FastStringUtils.java:88)
        at groovy.json.internal.FastStringUtils.toCharArray(FastStringUtils.java:175)
        at groovy.json.internal.CharBuf.addJsonFieldName(CharBuf.java:543)
        at groovy.json.JsonOutput.writeMap(JsonOutput.java:420)
        at groovy.json.JsonOutput.toJson(JsonOutput.java:198)
        at com.bertramlabs.plugins.hcl4j.HCLParserSpec.should generate Map from hcl(HCLParserSpec.groovy:43)

com.bertramlabs.plugins.hcl4j.HCLParserSpec > it should handle a vmware tf file FAILED
    java.lang.ClassCastException: class [B cannot be cast to class [C ([B and [C are in module java.base of loader 'bootstrap')
        at groovy.json.internal.FastStringUtils$StringImplementation$1.toCharArray(FastStringUtils.java:88)
        at groovy.json.internal.FastStringUtils.toCharArray(FastStringUtils.java:175)
        at groovy.json.internal.CharBuf.addJsonFieldName(CharBuf.java:543)
        at groovy.json.JsonOutput.writeMap(JsonOutput.java:420)
        at groovy.json.JsonOutput.toJson(JsonOutput.java:198)
        at com.bertramlabs.plugins.hcl4j.HCLParserSpec.it should handle a vmware tf file(HCLParserSpec.groovy:158)

com.bertramlabs.plugins.hcl4j.HCLParserSpec > should handle Map parsing FAILED
    java.lang.ClassCastException: class [B cannot be cast to class [C ([B and [C are in module java.base of loader 'bootstrap')
        at groovy.json.internal.FastStringUtils$StringImplementation$1.toCharArray(FastStringUtils.java:88)
        at groovy.json.internal.FastStringUtils.toCharArray(FastStringUtils.java:175)
        at groovy.json.internal.CharBuf.addJsonFieldName(CharBuf.java:543)
        at groovy.json.JsonOutput.writeMap(JsonOutput.java:420)
        at groovy.json.JsonOutput.toJson(JsonOutput.java:198)
        at com.bertramlabs.plugins.hcl4j.HCLParserSpec.should handle Map parsing(HCLParserSpec.groovy:178)

com.bertramlabs.plugins.hcl4j.HCLParserSpec > should handle interpolation syntax FAILED
    java.lang.ClassCastException: class [B cannot be cast to class [C ([B and [C are in module java.base of loader 'bootstrap')
        at groovy.json.internal.FastStringUtils$StringImplementation$1.toCharArray(FastStringUtils.java:88)
        at groovy.json.internal.FastStringUtils.toCharArray(FastStringUtils.java:175)
        at groovy.json.internal.CharBuf.addJsonFieldName(CharBuf.java:543)
        at groovy.json.JsonOutput.writeMap(JsonOutput.java:420)
        at groovy.json.JsonOutput.toJson(JsonOutput.java:198)
        at com.bertramlabs.plugins.hcl4j.HCLParserSpec.should handle interpolation syntax(HCLParserSpec.groovy:201)

com.bertramlabs.plugins.hcl4j.HCLParserSpec > should handle multiline string FAILED
    java.lang.ClassCastException: class [B cannot be cast to class [C ([B and [C are in module java.base of loader 'bootstrap')
        at groovy.json.internal.FastStringUtils$StringImplementation$1.toCharArray(FastStringUtils.java:88)
        at groovy.json.internal.FastStringUtils.toCharArray(FastStringUtils.java:175)
        at groovy.json.internal.CharBuf.addJsonFieldName(CharBuf.java:543)
        at groovy.json.JsonOutput.writeMap(JsonOutput.java:420)
        at groovy.json.JsonOutput.toJson(JsonOutput.java:198)
        at com.bertramlabs.plugins.hcl4j.HCLParserSpec.should handle multiline string(HCLParserSpec.groovy:225)

com.bertramlabs.plugins.hcl4j.HCLParserSpec > should handle stripped tabs multiline string FAILED
    java.lang.ClassCastException: class [B cannot be cast to class [C ([B and [C are in module java.base of loader 'bootstrap')
        at groovy.json.internal.FastStringUtils$StringImplementation$1.toCharArray(FastStringUtils.java:88)
        at groovy.json.internal.FastStringUtils.toCharArray(FastStringUtils.java:175)
        at groovy.json.internal.CharBuf.addJsonFieldName(CharBuf.java:543)
        at groovy.json.JsonOutput.writeMap(JsonOutput.java:420)
        at groovy.json.JsonOutput.toJson(JsonOutput.java:198)
        at com.bertramlabs.plugins.hcl4j.HCLParserSpec.should handle stripped tabs multiline string(HCLParserSpec.groovy:245)

com.bertramlabs.plugins.hcl4j.HCLParserSpec > it should handle single line blocks that are empty FAILED
    java.lang.ClassCastException: class [B cannot be cast to class [C ([B and [C are in module java.base of loader 'bootstrap')
        at groovy.json.internal.FastStringUtils$StringImplementation$1.toCharArray(FastStringUtils.java:88)
        at groovy.json.internal.FastStringUtils.toCharArray(FastStringUtils.java:175)
        at groovy.json.internal.CharBuf.addJsonFieldName(CharBuf.java:543)
        at groovy.json.JsonOutput.writeMap(JsonOutput.java:420)
        at groovy.json.JsonOutput.toJson(JsonOutput.java:198)
        at com.bertramlabs.plugins.hcl4j.HCLParserSpec.it should handle single line blocks that are empty(HCLParserSpec.groovy:260)

com.bertramlabs.plugins.hcl4j.HCLParserSpec > it should handle root level attributes FAILED
    java.lang.ClassCastException: class [B cannot be cast to class [C ([B and [C are in module java.base of loader 'bootstrap')
        at groovy.json.internal.FastStringUtils$StringImplementation$1.toCharArray(FastStringUtils.java:88)
        at groovy.json.internal.FastStringUtils.toCharArray(FastStringUtils.java:175)
        at groovy.json.internal.CharBuf.addJsonFieldName(CharBuf.java:543)
        at groovy.json.JsonOutput.writeMap(JsonOutput.java:420)
        at groovy.json.JsonOutput.toJson(JsonOutput.java:198)
        at com.bertramlabs.plugins.hcl4j.HCLParserSpec.it should handle root level attributes(HCLParserSpec.groovy:275)

com.bertramlabs.plugins.hcl4j.HCLParserSpec > it should handle values of variables being a block type FAILED
    java.lang.ClassCastException: class [B cannot be cast to class [C ([B and [C are in module java.base of loader 'bootstrap')
        at groovy.json.internal.FastStringUtils$StringImplementation$1.toCharArray(FastStringUtils.java:88)
        at groovy.json.internal.FastStringUtils.toCharArray(FastStringUtils.java:175)
        at groovy.json.internal.CharBuf.addJsonFieldName(CharBuf.java:543)
        at groovy.json.JsonOutput.writeMap(JsonOutput.java:420)
        at groovy.json.JsonOutput.toJson(JsonOutput.java:198)
        at com.bertramlabs.plugins.hcl4j.HCLParserSpec.it should handle values of variables being a block type(HCLParserSpec.groovy:296)

com.bertramlabs.plugins.hcl4j.HCLParserSpec > it should handle multiline interpolated strings FAILED
    java.lang.ClassCastException: class [B cannot be cast to class [C ([B and [C are in module java.base of loader 'bootstrap')
        at groovy.json.internal.FastStringUtils$StringImplementation$1.toCharArray(FastStringUtils.java:88)
        at groovy.json.internal.FastStringUtils.toCharArray(FastStringUtils.java:175)
        at groovy.json.internal.CharBuf.addJsonFieldName(CharBuf.java:543)
        at groovy.json.JsonOutput.writeMap(JsonOutput.java:420)
        at groovy.json.JsonOutput.toJson(JsonOutput.java:198)
        at com.bertramlabs.plugins.hcl4j.HCLParserSpec.it should handle multiline interpolated strings(HCLParserSpec.groovy:380)

com.bertramlabs.plugins.hcl4j.HCLParserSpec > it should handle dollar sign in the password field FAILED
    java.lang.ClassCastException: class [B cannot be cast to class [C ([B and [C are in module java.base of loader 'bootstrap')
        at groovy.json.internal.FastStringUtils$StringImplementation$1.toCharArray(FastStringUtils.java:88)
        at groovy.json.internal.FastStringUtils.toCharArray(FastStringUtils.java:175)
        at groovy.json.internal.CharBuf.addJsonFieldName(CharBuf.java:543)
        at groovy.json.JsonOutput.writeMap(JsonOutput.java:420)
        at groovy.json.JsonOutput.toJson(JsonOutput.java:198)
        at com.bertramlabs.plugins.hcl4j.HCLParserSpec.it should handle dollar sign in the password field(HCLParserSpec.groovy:397)

com.bertramlabs.plugins.hcl4j.HCLParserSpec > it should handle quoted property names FAILED
    java.lang.ClassCastException: class [B cannot be cast to class [C ([B and [C are in module java.base of loader 'bootstrap')
        at groovy.json.internal.FastStringUtils$StringImplementation$1.toCharArray(FastStringUtils.java:88)
        at groovy.json.internal.FastStringUtils.toCharArray(FastStringUtils.java:175)
        at groovy.json.internal.CharBuf.addJsonFieldName(CharBuf.java:543)
        at groovy.json.JsonOutput.writeMap(JsonOutput.java:420)
        at groovy.json.JsonOutput.toJson(JsonOutput.java:198)
        at com.bertramlabs.plugins.hcl4j.HCLParserSpec.it should handle quoted property names(HCLParserSpec.groovy:426)

com.bertramlabs.plugins.hcl4j.HCLParserSpec > it should handle closures inside an array FAILED
    java.lang.ClassCastException: class [B cannot be cast to class [C ([B and [C are in module java.base of loader 'bootstrap')
        at groovy.json.internal.FastStringUtils$StringImplementation$1.toCharArray(FastStringUtils.java:88)
        at groovy.json.internal.FastStringUtils.toCharArray(FastStringUtils.java:175)
        at groovy.json.internal.CharBuf.addJsonFieldName(CharBuf.java:543)
        at groovy.json.JsonOutput.writeMap(JsonOutput.java:420)
        at groovy.json.JsonOutput.toJson(JsonOutput.java:198)
        at com.bertramlabs.plugins.hcl4j.HCLParserSpec.it should handle closures inside an array(HCLParserSpec.groovy:445)

com.bertramlabs.plugins.hcl4j.HCLParserSpec > it should handle comments inside an array FAILED
    java.lang.ClassCastException: class [B cannot be cast to class [C ([B and [C are in module java.base of loader 'bootstrap')
        at groovy.json.internal.FastStringUtils$StringImplementation$1.toCharArray(FastStringUtils.java:88)
        at groovy.json.internal.FastStringUtils.toCharArray(FastStringUtils.java:175)
        at groovy.json.internal.CharBuf.addJsonFieldName(CharBuf.java:543)
        at groovy.json.JsonOutput.writeMap(JsonOutput.java:420)
        at groovy.json.JsonOutput.toJson(JsonOutput.java:198)
        at com.bertramlabs.plugins.hcl4j.HCLParserSpec.it should handle comments inside an array(HCLParserSpec.groovy:461)

com.bertramlabs.plugins.hcl4j.HCLParserSpec > it should handle closing block on same line as value hcl2 STANDARD_OUT
    [provider:[vsphere:[user:com.bertramlabs.plugins.hcl4j.RuntimeSymbols.Variable@62213e7c, password:com.bertramlabs.plugins.hcl4j.RuntimeSymbols.Variable@41e21dda, vsphere_server:com.bertramlabs.plugins.hcl4j.RuntimeSymbols.Variable@22ee7c6f, version:~> 1.11.0, allow_unverified_ssl:true]], data:[vsphere_datacenter:[dc:[name:wheeler]], vsphere_datastore:[datastore:[name:wheeler-vsan, datacenter_id:com.bertramlabs.plugins.hcl4j.RuntimeSymbols.Variable@311c715e]], vsphere_resource_pool:[pool:[name:terraform, datacenter_id:${data.vsphere_datacenter.dc.id}]], vsphere_network:[network:[name:wheeler-vms, datacenter_id:com.bertramlabs.plugins.hcl4j.RuntimeSymbols.Variable@5a256bdf]], vsphere_virtual_machine:[template:[name:Morpheus Ubuntu 18.04.2 v1, datacenter_id:com.bertramlabs.plugins.hcl4j.RuntimeSymbols.Variable@b78a18c]]], resource:[tls_private_key:[bw-key-1:[algorithm:RSA, rsa_bits:4096.0]], vsphere_virtual_machine:[vm-1:[name:terraform-test-1, resource_pool_id:com.bertramlabs.plugins.hcl4j.RuntimeSymbols.Variable@8e0b513, datastore_id:com.bertramlabs.plugins.hcl4j.RuntimeSymbols.Variable@79ea5c43, num_cpus:1.0, memory:1024.0, guest_id:ubuntu64Guest, network_interface:[network_id:com.bertramlabs.plugins.hcl4j.RuntimeSymbols.Variable@3750e633], disk:[label:disk0, thin_provisioned:true, size:20.0], clone:[template_uuid:com.bertramlabs.plugins.hcl4j.RuntimeSymbols.Variable@484771b8], connection:[type:ssh, user:cloud-user, private_key:com.bertramlabs.plugins.hcl4j.RuntimeSymbols.Variable@45020d8e, password:password]]]], output:[tls_private_key:[value:null]]]

com.bertramlabs.plugins.hcl4j.HCLParserSpec > it should handle multiline delimiters FAILED
    java.lang.ClassCastException: class [B cannot be cast to class [C ([B and [C are in module java.base of loader 'bootstrap')
        at groovy.json.internal.FastStringUtils$StringImplementation$1.toCharArray(FastStringUtils.java:88)
        at groovy.json.internal.FastStringUtils.toCharArray(FastStringUtils.java:175)
        at groovy.json.internal.CharBuf.addJsonFieldName(CharBuf.java:543)
        at groovy.json.JsonOutput.writeMap(JsonOutput.java:420)
        at groovy.json.JsonOutput.toJson(JsonOutput.java:198)
        at com.bertramlabs.plugins.hcl4j.HCLParserSpec.it should handle multiline delimiters(HCLParserSpec.groovy:628)
```

</details>