### PR TITLE
Remove slf4j-parent

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,6 @@ dependencies {
     api 'com.fasterxml.jackson.core:jackson-databind:2.14.1'
     api 'com.fasterxml.jackson.core:jackson-annotations:2.16.1'
     api 'com.fasterxml.jackson.core:jackson-core:2.16.1'
-    api "org.slf4j:slf4j-parent:1.7.36"
     api "org.slf4j:slf4j-api:1.7.36"
     api 'org.apache.httpcomponents:httpclient:4.5.14'
     api 'org.apache.httpcomponents:httpcore:4.4.15'

--- a/build.gradle
+++ b/build.gradle
@@ -144,7 +144,7 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
     from 'build/docs/javadoc'
 }
 
-task sourcesJar(type: Jar) {
+task sourcesJar(type: Jar, dependsOn: jflex) {
     archiveClassifier = 'sources'
     from sourceSets.main.allSource
 }


### PR DESCRIPTION
I don't know what it is, I'm not sure it even does anything, never seen it before.

But when I tried using the library I was met a maven error cause it couldn't find it:
Could not find artifact org.slf4j:slf4j-parent:jar:1.7.36 in central (https://repo.maven.apache.org/maven2)