### PR TITLE
Fix NPE in startswith condition if no default is provided

### DIFF
--- a/src/main/java/com/bertramlabs/plugins/hcl4j/HCLBaseFunctions.java
+++ b/src/main/java/com/bertramlabs/plugins/hcl4j/HCLBaseFunctions.java
@@ -162,7 +162,7 @@ public class HCLBaseFunctions {
         });
 
         parser.registerFunction("startswith", (arguments) -> {
-            if(arguments.size() == 2) {
+            if(arguments.size() == 2 && arguments.get(0) != null && arguments.get(1) != null) {
                 String prefix = (String)(arguments.get(1));
                 String value = (String)(arguments.get(0));
                 return value.startsWith(prefix);

--- a/src/test/groovy/com/bertramlabs/plugins/hcl4j/HCLParserSpec.groovy
+++ b/src/test/groovy/com/bertramlabs/plugins/hcl4j/HCLParserSpec.groovy
@@ -1737,6 +1737,46 @@ resource "aws_instance" "bw-instance-1" {
 	results.resource["aws_instance"]["bw-instance-1"] != null
 
 	}
+
+	void "should parse startswith correctly if no default is provided from hcl"() {
+		given:
+
+		def hcl = '''
+variable "server_id" {
+  type        = string
+  description = "Server ID"
+  validation {
+    condition     = length(var.server_id) == 19
+    error_message = "Server ID must be 19 characters long"
+  }
+  validation {
+    condition     = startswith(var.server_id, "s-")
+    error_message = "Server ID must start with 's-'"
+  }
+  validation {
+    condition     = lower(var.server_id) == var.server_id
+    error_message = "Server ID must be lowercase"
+  }
+}
+'''
+		HCLParser parser = new HCLParser();
+		when:
+		def results  = parser.parse(hcl)
+		then:
+		results.containsKey('variable')
+		results.variable.containsKey("server_id")
+		results.variable.server_id.type.name == "string"
+		results.variable.server_id.description == "Server ID"
+		results.variable.server_id.validation.size() == 3
+		results.variable.server_id.validation[0].condition == false
+		results.variable.server_id.validation[0].error_message == "Server ID must be 19 characters long"
+		results.variable.server_id.validation[1].condition == null
+		results.variable.server_id.validation[1].error_message == "Server ID must start with 's-'"
+		results.variable.server_id.validation[2].condition == true
+		results.variable.server_id.validation[2].error_message == "Server ID must be lowercase"
+
+	}
+
 }
 
 


### PR DESCRIPTION
When adding a variable without a default and using a var in conditions, null is returned for the variable (as expected, it's not assigned)
most places are NPE protected, however in startswith condition an NPE will be thrown and the parsing will fail.

```
variable "server_id" {
  type        = string
  description = "Server ID"
  validation {
    condition     = length(var.server_id) == 19
    error_message = "Server ID must be 19 characters long"
  }
  validation {
    condition     = startswith(var.server_id, "s-")
    error_message = "Server ID must start with 's-'"
  }
  validation {
    condition     = lower(var.server_id) == var.server_id
    error_message = "Server ID must be lowercase"
  }
}
```

Simple fix just to check null on the values before doing value.startsWith(prefix); (as both value and prefix are NonNull)